### PR TITLE
[wip] Add counterexample finding with hypothesis

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/hypothesis-jsonschema"]
+	path = vendor/hypothesis-jsonschema
+	url = https://github.com/bollwyvl/hypothesis-jsonschema

--- a/anaconda-project.yml
+++ b/anaconda-project.yml
@@ -4,7 +4,11 @@ commands:
   lab:
     unix: jupyter lab --no-browser --debug
   setup:
-    unix: python -m pip install -e .
+    unix: |-
+      pushd vendor/hypothesis-jsonscheam \
+      && python -m pip install -e . \
+      && popd \
+      && python -m pip install -e .
   test:
     unix: pytest
   lint:
@@ -19,7 +23,6 @@ env_specs:
       - click
       - git
       - hypothesis
-      - hypothesis-jsonschema
       - isort
       - jupyterlab ==2.0.1
       - mypy

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,6 @@ dependencies:
   - click
   - git
   - hypothesis
-  - hypothesis-jsonschema
   - isort
   - jupyterlab ==2.0.1
   - mypy

--- a/src/expectorate/lsp/base.py
+++ b/src/expectorate/lsp/base.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+from logging import Logger
+from pathlib import Path
+
+
+@dataclass
+class Base:
+    workdir: Path
+    output: Path
+    log: Logger

--- a/src/expectorate/lsp/generate.py
+++ b/src/expectorate/lsp/generate.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import re
 import subprocess
 from dataclasses import dataclass
@@ -13,15 +12,12 @@ import pyemojify
 
 from ..utils import ensure_js_package, ensure_repo
 from . import constants
+from .base import Base
 from .conventions import CONVENTIONS, SpecConvention
 
 
 @dataclass
-class SpecGenerator:
-    workdir: Path
-    output: Path
-    log: logging.Logger
-
+class SpecGenerator(Base):
     lsp_dir: Optional[Path] = None
     vlspn_dir: Optional[Path] = None
 

--- a/src/expectorate/lsp/validate.py
+++ b/src/expectorate/lsp/validate.py
@@ -1,0 +1,78 @@
+import copy
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import hypothesis_jsonschema
+
+from .base import Base
+
+# TODO: use these
+# import subprocess
+# import tempfile
+# import hypothesis
+# from pathlib import Path
+# import jinja2
+# import jsonschema
+# from hypothesis import assume, given, settings
+
+
+@dataclass
+class SpecValidator(Base):
+    feature_strategies: Optional[Any] = None
+    raw_schema: Optional[Dict[Any, Any]] = None
+    cleaned_schema: Optional[Dict[Any, Any]] = None
+
+    def validate(self) -> int:
+        self.load_schema()
+        self.clean_schema()
+        self.make_strategies()
+        return 1
+
+    def load_schema(self):
+        schema_path = next(self.output.glob("lsp*synthetic.schema.json"))
+        self.raw_schema = json.loads(schema_path.read_text())
+
+    def clean_schema(self):
+        """ at present, we can't merge `description` properties: this brute
+            forces all string descriptions
+        """
+        assert self.raw_schema
+
+        def _strip_desc(schema) -> Any:
+            if isinstance(schema, dict):
+                val = schema.get("description")
+                if isinstance(val, str):
+                    schema.pop("description")
+                return {k: _strip_desc(v) for k, v in schema.items()}
+            elif isinstance(schema, list):
+                return [_strip_desc(v) for v in schema]
+            else:
+                return schema
+
+        self.cleaned_schema = _strip_desc(copy.deepcopy(self.raw_schema))
+
+    def make_strategies(self):
+        """ make strategies for each feature
+
+            We don't want, and can't, use _AnyFeature as a baseline for the strategy:
+            - it's too big
+            - it has some circular references, apparently
+        """
+        assert self.cleaned_schema
+        schema = self.cleaned_schema
+        defs = schema["definitions"]
+        features = defs["_AnyFeature"]["anyOf"]
+        strats = self.feature_strategies = {}
+
+        for feature in features:
+            feature_ref = feature["$ref"].split("/")[-1]
+            feature_name = feature_ref.replace("Feature", "")
+            feature_schema = {k: v for k, v in schema.items() if k not in ["$ref"]}
+            feature_schema.update(defs[feature_ref])
+            strat = None
+            try:
+                strat = hypothesis_jsonschema.from_schema(feature_schema)
+            except Exception as err:
+                self.log.warn(str(err)[:64])
+            strats[feature_name] = strat

--- a/src/expectorate/tests/test_cli_lsp.py
+++ b/src/expectorate/tests/test_cli_lsp.py
@@ -49,7 +49,7 @@ def test_lsp_cli_default(runner_with_args_and_paths):
     """ happy day, using pre-validated commits from `constants.py`
     """
     runner, args, workdir, output = runner_with_args_and_paths
-    result = runner.invoke(cli, [*args, "lsp"], catch_exceptions=False)
+    result = runner.invoke(cli, [*args, "lsp", "generate"], catch_exceptions=False)
     assert result.exit_code == 0, result.__dict__
     assert_generated(workdir, output)
 
@@ -66,7 +66,7 @@ def test_lsp_cli_args(label, extra_args, runner_with_args_and_paths):
     """ try parsing a number of combinations of relevant combinations
     """
     runner, args, workdir, output = runner_with_args_and_paths
-    final_args = [*args, "lsp", *extra_args]
+    final_args = [*args, "lsp", "generate", *extra_args]
     result = runner.invoke(cli, final_args, catch_exceptions=False)
     assert result.exit_code == 0, result.__dict__
 


### PR DESCRIPTION
Goal: Use the generated JSON schema to find counterexamples that aren't valid under the reference implementation.

This won't be able to find things that typescript thinks are valid, but the schema doesn't.

- [x] vendors in this PR of hypothesis-jsonschema to handle some of the deep refs:
  - https://github.com/Zac-HD/hypothesis-jsonschema/pull/34
- [x] splits out `lsp` cli into `generate` and `validate`
- [x] generates a hypothesis strategy per feature
  - [ ] make this a dataframe
- [ ] oracle: generate templated typescript, try to compile it
- [ ] use the oracle to find counterexamples