### PR TITLE
Update to generate a schema for version 3.15

### DIFF
--- a/src/expectorate/lsp/constants.py
+++ b/src/expectorate/lsp/constants.py
@@ -1,9 +1,11 @@
 LSP_REPO = "https://github.com/microsoft/language-server-protocol.git"
-LSP_COMMIT = "639528c"
-LSP_SPEC_VERSION = "3.14"
+# https://github.com/microsoft/language-server-protocol/commit/0689f45bbd72637eb71d671cf9d9b728bf7edc8a
+LSP_COMMIT = "0689f45b"
+LSP_SPEC_VERSION = "3.15"
 
-VLSPN_COMMIT = "6a7e832"
 VLSPN_REPO = "https://github.com/microsoft/vscode-languageserver-node.git"
+# https://github.com/microsoft/vscode-languageserver-node/commit/48f496b997be3f46329a55004022ba615d6befd3
+VLSPN_COMMIT = "48f496b"
 
 PRETTIER_VERSION = "2.0.2"
 TSSG_VERSION = "0.65.0"

--- a/src/expectorate/lsp/generate.py
+++ b/src/expectorate/lsp/generate.py
@@ -87,8 +87,7 @@ class SpecGenerator:
         if self.lsp_dir is not None:
             spec_md = (
                 self.lsp_dir
-                / "_specifications"
-                / f"""specification-{self.lsp_spec.version.replace('.', '-')}.md"""
+                / "specification.md"
             )
             self.raw_spec = spec_md.read_text()
 


### PR DESCRIPTION
This is probably a little bit rough. And I'm not sure if those are the exact right commits to use for the two repos. I did request a git tag at https://github.com/microsoft/language-server-protocol/issues/952

And I haven't verified the accuracy of the generated schema.